### PR TITLE
WIP: Add api connect timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Table of Contents
   *   [Enable/Disable Captcha](#captcha-support)
   *   [Extracting Real IP Address](#real-ip)
   *   [Filter Sensitive Headers](#sensitive-headers)
-  *   [API Timeout Milliseconds](#api-timeout)
+  *   [API Timeouts](#api-timeout)
   *   [Send Page Activities](#send-page-activities)
   *   [Debug Mode](#debug-mode)
 -   [Contributing](#contributing)
@@ -231,11 +231,12 @@ $perimeterxConfig = [
 ]
 ```
 
-#### <a name="api-timeout"></a>API Timeout Milliseconds
+#### <a name="api-timeout"></a>API Timeouts
 
-Timeout in seconds (float) to wait for the PerimeterX server API response.
-The API is called when the risk cookie does not exist, or is expired or
-invalid.
+Control the timeouts for PerimeterX requests. The API is called when the risk cookie does not exist, or is expired or invalid.
+
+API Timeout in seconds (float) to wait for the PerimeterX server API response.
+
 
 **default:** 1
 
@@ -246,6 +247,21 @@ $perimeterxConfig = [
     ..
 ]
 ```
+
+API Connection Timeout in seconds (float) to wait for the connection to the PerimeterX server API.
+
+
+**default:** 1
+
+```php
+$perimeterxConfig = [
+  ..
+    'api_connect_timeout' => 2
+    ..
+]
+```
+
+
 
 #### <a name="send-page-activities"></a> Send Page Activities
 

--- a/src/Perimeterx.php
+++ b/src/Perimeterx.php
@@ -87,6 +87,7 @@ final class Perimeterx
                 'debug_mode' => false,
                 'module_mode' => Perimeterx::$ACTIVE_MODE,
                 'api_timeout' => 1,
+                'api_connect_timeout' => 1,
                 'perimeterx_server_host' => 'https://sapi-cdn.perimeterx.net',
                 'http_client' => $httpClient,
                 'local_proxy' => false

--- a/src/PerimeterxActivitiesClient.php
+++ b/src/PerimeterxActivitiesClient.php
@@ -73,6 +73,6 @@ class PerimeterxActivitiesClient
 
         $activities = [ $pxData ];
         $headers = [ 'Content-Type' => 'application/json' ];
-        $this->httpClient->send('/api/v1/collector/s2s', 'POST', $activities, $headers, $this->pxConfig['api_timeout']);
+        $this->httpClient->send('/api/v1/collector/s2s', 'POST', $activities, $headers, $this->pxConfig['api_timeout'], $this->pxConfig['api_connect_timeout']);
     }
 }

--- a/src/PerimeterxCaptchaValidator.php
+++ b/src/PerimeterxCaptchaValidator.php
@@ -58,7 +58,7 @@ class PerimeterxCaptchaValidator
             'Authorization' => 'Bearer ' . $this->pxConfig['auth_token'],
             'Content-Type' => 'application/json'
         ];
-        $response = $this->httpClient->send('/api/v1/risk/captcha', 'POST', $requestBody, $headers, $pxConfig['api_timeout']);
+        $response = $this->httpClient->send('/api/v1/risk/captcha', 'POST', $requestBody, $headers, $pxConfig['api_timeout'], $pxConfig['api_connect_timeout']);
         return $response;
     }
 

--- a/src/PerimeterxHttpClient.php
+++ b/src/PerimeterxHttpClient.php
@@ -25,10 +25,17 @@ class PerimeterxHttpClient
      * @inheritdoc
      * @return string
      */
-    public function send($url, $method, $json, $headers, $timeout = 0)
+    public function send($url, $method, $json, $headers, $timeout = 0, $connect_timeout = 0)
     {
         try {
-            $rawResponse = $this->client->request($method, $url, ['json' => $json, 'headers' => $headers, 'timeout' => $timeout]);
+            $rawResponse = $this->client->request($method, $url, 
+                [
+                'json' => $json, 
+                'headers' => $headers, 
+                'timeout' => $timeout,
+                'connect_timeout' => $connect_timeout
+                ]
+            );
         } catch (RequestException $e) {
             error_log('http error ' . $e->getCode() . ' ' . $e->getMessage());
             return null;

--- a/src/PerimeterxS2SValidator.php
+++ b/src/PerimeterxS2SValidator.php
@@ -77,7 +77,7 @@ class PerimeterxS2SValidator
         if ($this->pxConfig['module_mode'] != Perimeterx::$ACTIVE_MODE and isset($this->pxConfig['custom_risk_handler'])) {
             $response = $this->pxConfig['custom_risk_handler']($this->pxConfig['perimeterx_server_host'] . self::RISK_API_ENDPOINT, 'POST', $requestBody, $headers);
         } else {
-            $response = $this->httpClient->send(self::RISK_API_ENDPOINT, 'POST', $requestBody, $headers, $this->pxConfig['api_timeout']);
+            $response = $this->httpClient->send(self::RISK_API_ENDPOINT, 'POST', $requestBody, $headers, $this->pxConfig['api_timeout'], $this->pxConfig['api_connect_timeout']);
         }
         return $response;
     }


### PR DESCRIPTION
Haven't tested this, but wanted to see if this is something that would get pulled in.

Guzzle Supports the connect-timeout option, and defaults to wait indefinitely which can cause problems in production.

Guzzle Docs:
http://docs.guzzlephp.org/en/latest/request-options.html#connect-timeout