### PR TITLE
Fix notice for : "Undefined offset: 1"

### DIFF
--- a/src/PerimeterxContext.php
+++ b/src/PerimeterxContext.php
@@ -9,17 +9,12 @@ class PerimeterxContext
      */
     public function __construct($pxConfig)
     {
-        if (isset($_SERVER['HTTP_COOKIE'])) {
-            foreach (explode('; ', $_SERVER['HTTP_COOKIE']) as $rawcookie) {
-                if (!empty($rawcookie)) {
-                    list($k, $v) = explode('=', $rawcookie, 2);
-                    if ($k == '_px') {
-                        $this->px_cookie = $v;
-                    }
-                    if ($k == '_pxCaptcha') {
-                        $this->px_captcha = $v;
-                    }
-                }
+        if (!empty($_COOKIE)) {
+            if (isset($_COOKIE["_px"])) {
+                $this->px_cookie = $_COOKIE["_px"];
+            }
+            if (isset($_COOKIE["_pxCaptcha"])) {
+                $this->px_captcha = $_COOKIE["_pxCaptcha"];
             }
         }
 


### PR DESCRIPTION
Is there a reason HTTP_COOKIE is being used here instead of $_COOKIE?
if $_COOKIE works for this usecase it simplifies the logic and removes the undefined offset that list is throwing when trying to explode $rawcookie with no equals sign.

Either we can do something like this patch, or at least do a strpos before doing the explode to list.