### PR TITLE
Fix Cookie Decryption Errors

### DIFF
--- a/src/PerimeterxContext.php
+++ b/src/PerimeterxContext.php
@@ -9,12 +9,17 @@ class PerimeterxContext
      */
     public function __construct($pxConfig)
     {
-        if (!empty($_COOKIE)) {
-            if (isset($_COOKIE["_px"])) {
-                $this->px_cookie = $_COOKIE["_px"];
-            }
-            if (isset($_COOKIE["_pxCaptcha"])) {
-                $this->px_captcha = $_COOKIE["_pxCaptcha"];
+        if (isset($_SERVER['HTTP_COOKIE'])) {
+            foreach (explode('; ', $_SERVER['HTTP_COOKIE']) as $rawcookie) {
+                if (!empty($rawcookie) && strpos($rawcookie, '=') !== false) {
+                    list($k, $v) = explode('=', $rawcookie, 2);
+                    if ($k == '_px') {
+                       $this->px_cookie = $v;
+                    }
+                    if ($k == '_pxCaptcha') {
+                       $this->px_captcha = $v;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This is an amendment to the previous fix for the notice: "Undefined offset: 1".  $_COOKIE returns the cookie with spaces in the value in place of + signs, causing the cookie decryption to fail.  Using HTTP_COOKIE returns the correct cookie value and the strpos() check blocks bad cookie values, stopping the notice.