### PR TITLE
Add `custom_uri` handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Table of Contents
   *   [Custom Block Action](#custom-block)
   *   [Enable/Disable Captcha](#captcha-support)
   *   [Extracting Real IP Address](#real-ip)
+  *   [Custom URI](#custom-uri)
   *   [Filter Sensitive Headers](#sensitive-headers)
   *   [API Timeouts](#api-timeout)
   *   [Send Page Activities](#send-page-activities)
@@ -212,6 +213,25 @@ $perimeterxConfig['custom_user_ip'] = function ($pxCtx)
     $ip = $headers['X-REAL-CLIENT-IP'];
 
     return $ip;
+};
+
+$px = Perimeterx::Instance($perimeterxConfig);
+$px->pxVerify();
+```
+
+#### <a name="custom-uri"></a>Custom URI
+
+The URI can be returned to the PerimeterX module using a custom user function defined on $perimeterxConfig.
+
+**default:** `$_SERVER['REQUEST_URI']`
+
+```php
+/**
+ * @param \Perimeterx\PerimeterxContext $pxCtx
+ */
+$perimeterxConfig['custom_uri'] = function ($pxCtx)
+{
+    return $_SERVER['HTTP_X_CUSTOM_URI'];
 };
 
 $px = Perimeterx::Instance($perimeterxConfig);

--- a/integration-example.php
+++ b/integration-example.php
@@ -30,6 +30,13 @@ $perimeterxConfig = [
      *      // user defined logic comes here
      * },
      */
+
+    /*
+     * 'custom_uri' => function ($pxCtx)
+     * {
+     *      return $_SERVER['HTTP_X_CUSTOM_URI'];
+     * },
+     */
 ];
 
 $px = Perimeterx::Instance($perimeterxConfig);

--- a/src/PerimeterxContext.php
+++ b/src/PerimeterxContext.php
@@ -38,7 +38,11 @@ class PerimeterxContext
         $this->hostname = $_SERVER['HTTP_HOST'];
         // User Agent isn't always sent by bots so handle it gracefully.
         $this->userAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
-        $this->uri = $_SERVER['REQUEST_URI'];
+        if (isset($pxConfig['custom_uri'])) {
+            $this->uri = $pxConfig['custom_uri']($this);
+        } else {
+            $this->uri = $_SERVER['REQUEST_URI'];
+        }
         $this->full_url = $this->selfURL();
         $this->score = 0;
 
@@ -329,7 +333,7 @@ class PerimeterxContext
         $l = strtolower($_SERVER["SERVER_PROTOCOL"]);
         $protocol = substr($l, 0, strpos($l, "/")) . $s;
         $port = ($_SERVER["SERVER_PORT"] == "80") ? "" : (":" . $_SERVER["SERVER_PORT"]);
-        return $protocol . "://" . $_SERVER['HTTP_HOST'] . $port . $_SERVER['REQUEST_URI'];
+        return $protocol . "://" . $_SERVER['HTTP_HOST'] . $port . $this->uri;
     }
 
     /**


### PR DESCRIPTION
This adds a `custom_uri` handler to allow for customizing what URI is sent to PerimeterX. One use case would be a uri rewrite middleware that passes along the original uri via a header but `$_SERVER['REQUEST_URI']` contains a dispatcher page.