### PR TITLE
Make S2S Risk API Call Error Messages Available

### DIFF
--- a/src/PerimeterxContext.php
+++ b/src/PerimeterxContext.php
@@ -149,6 +149,16 @@ class PerimeterxContext
      * @var string user's score.
      */
     protected $uuid;
+    
+    /**
+     * @var bool true if request was sent to S2S risk api
+     */
+    protected $is_made_s2s_api_call;
+    
+    /**
+     * @var string S2S api call HTTP error message
+     */
+    protected $s2s_http_error_msg;
 
     /**
      * @return string
@@ -196,6 +206,38 @@ class PerimeterxContext
     public function setUuid($uuid)
     {
         $this->uuid = $uuid;
+    }
+    
+    /**
+     * @param string $is_made_s2s_api_call
+     */
+    public function setIsMadeS2SRiskApiCall($is_made_s2s_api_call)
+    {
+        $this->is_made_s2s_api_call = $is_made_s2s_api_call;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIsMadeS2SRiskApiCall()
+    {
+        return $this->is_made_s2s_api_call;
+    }
+
+    /**
+     * @param string $s2s_http_error_msg
+     */
+    public function setS2SHttpErrorMsg($s2s_http_error_msg)
+    {
+        $this->s2s_http_error_msg = $s2s_http_error_msg;
+    }
+
+    /**
+     * @return string
+     */
+    public function getS2SHttpErrorMsg()
+    {
+        return $this->s2s_http_error_msg;
     }
 
     /**

--- a/src/PerimeterxHttpClient.php
+++ b/src/PerimeterxHttpClient.php
@@ -38,7 +38,7 @@ class PerimeterxHttpClient
             );
         } catch (RequestException $e) {
             error_log('http error ' . $e->getCode() . ' ' . $e->getMessage());
-            return null;
+            return json_encode(['error_msg' => $e->getMessage()]);
         }
 
         $rawBody = (string)$rawResponse->getBody();

--- a/src/PerimeterxS2SValidator.php
+++ b/src/PerimeterxS2SValidator.php
@@ -106,6 +106,7 @@ class PerimeterxS2SValidator
     public function verify()
     {
         $response = json_decode($this->sendRiskRequest());
+        $this->pxCtx->setIsMadeS2SRiskApiCall(true);
         if (isset($response, $response->scores, $response->scores->non_human)) {
             $score = $response->scores->non_human;
             $this->pxCtx->setScore($score);
@@ -113,6 +114,9 @@ class PerimeterxS2SValidator
             if ($score >= $this->pxConfig['blocking_score']) {
                 $this->pxCtx->setBlockReason('s2s_high_score');
             }
+        }
+        if (isset($response, $response->error_msg)) {
+            $this->pxCtx->setS2SHttpErrorMsg($response->error_msg);
         }
     }
 }


### PR DESCRIPTION
We needed to be able to see the error messages being sent back from the S2SValidator's Risk API call and to check if a call was made.  This makes the call status and any error messages available.

This is live and working on our site.