### PR TITLE
add `Authorization` header to activities calls

### DIFF
--- a/src/PerimeterxActivitiesClient.php
+++ b/src/PerimeterxActivitiesClient.php
@@ -72,7 +72,11 @@ class PerimeterxActivitiesClient
         }
 
         $activities = [ $pxData ];
-        $headers = [ 'Content-Type' => 'application/json' ];
+
+        $headers = [
+            'Authorization' => 'Bearer ' . $this->pxConfig['auth_token'],
+            'Content-Type' => 'application/json'
+        ];
         $this->httpClient->send('/api/v1/collector/s2s', 'POST', $activities, $headers, $this->pxConfig['api_timeout'], $this->pxConfig['api_connect_timeout']);
     }
 }


### PR DESCRIPTION
The `Authorization` header is missing in activities calls. This doesn't appear consistent with the other sdks.

https://github.com/PerimeterX/perimeterx-java-sdk/blob/master/src/main/java/com/perimeterx/http/PXHttpClient.java#L92

```java
String requestBody = JsonUtils.writer.writeValueAsString(activity);
logger.info("Sending Activity: {}", requestBody);
HttpPost post = new HttpPost(baseUrl + Constants.API_ACTIVITIES);
post.setEntity(new StringEntity(requestBody, UTF_8));
post.setHeader("Authorization", "Bearer " + authToken);
post.setHeader("Content-Type", "application/json");
httpResponse = httpClient.execute(post);
EntityUtils.consume(httpResponse.getEntity());
```

https://github.com/PerimeterX/mod_perimeterx/blob/779c1a8ba1651ddbeeb01a7e5d0efc54cdf5298f/mod_perimeterx.c#L946

```c
char *activity = create_activity(activity_type, conf, ctx);
if (!activity) {
    ERROR(ctx->r->server, "post_verification: (%s) create activity failed", activity_type);
    return;
}
char *resp = post_request(conf->activities_api_url, activity, conf->auth_header, ctx->r, conf->curl_pool);
free(activity);
if (resp) {
    free(resp);
} else {
    ERROR(ctx->r->server, "post_verification: (%s) send failed", activity_type);
}
```