### PR TITLE
Add PSR-3 Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Table of Contents
   *   [Filter Sensitive Headers](#sensitive-headers)
   *   [API Timeouts](#api-timeout)
   *   [Send Page Activities](#send-page-activities)
+  *   [Logging](#logging)
   *   [Debug Mode](#debug-mode)
 -   [Contributing](#contributing)
   *   [Tests](#tests)
@@ -297,6 +298,20 @@ amount requests blocked and API usage statistics.
 $perimeterxConfig = [
 	..
     'send_page_activities' => true
+    ..
+]
+```
+
+#### <a name="logging"></a> Logging
+
+Log messages via an implementation of `\Psr\Log\LoggerInterface` (see [PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md) for full interface specification). By default, an instance of `\Perimeterx\PerimeterxLogger` is used which will log all message via PHP's `error_log` function.
+
+**default:** `\Perimeterx\PerimeterxLogger` instance
+
+```php
+$perimeterxConfig = [
+    ..
+    'logger' => new \My\Psr\Log\ConcreteLogger()
     ..
 ]
 ```

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
   "type": "library",
   "require": {
     "guzzlehttp/guzzle": "~6.0",
-    "php": ">=5.5"
+    "php": ">=5.5",
+    "psr/log": "^1.0"
   },
   "config": {
     "optimize-autoloader": true

--- a/src/Perimeterx.php
+++ b/src/Perimeterx.php
@@ -129,7 +129,7 @@ final class Perimeterx
             };
             return $this->handleVerification($pxCtx);
         } catch (\Exception $e) {
-            error_log('Uncaught exception while verifying perimiterx score' . $e->getCode() . ' ' . $e->getMessage());
+            $this->pxConfig['logger']->error('Uncaught exception while verifying perimeterx score' . $e->getCode() . ' ' . $e->getMessage());
             return 1;
         }
     }

--- a/src/Perimeterx.php
+++ b/src/Perimeterx.php
@@ -91,6 +91,10 @@ final class Perimeterx
                 'local_proxy' => false
             ], $pxConfig);
 
+            if (empty($this->pxConfig['logger'])) {
+                $this->pxConfig['logger'] = new PerimeterxLogger();
+            }
+
             $httpClient = new PerimeterxHttpClient($this->pxConfig);
             $this->pxConfig['http_client'] = $httpClient;
             $this->pxActivitiesClient = new PerimeterxActivitiesClient($this->pxConfig);

--- a/src/Perimeterx.php
+++ b/src/Perimeterx.php
@@ -25,6 +25,8 @@
 
 namespace Perimeterx;
 
+use Psr\Log\LoggerInterface;
+
 final class Perimeterx
 {
     /**
@@ -68,6 +70,9 @@ final class Perimeterx
         }
         if (!isset($pxConfig['auth_token'])) {
             throw new PerimeterxException(PerimeterxException::$AUTH_TOKEN_MISSING);
+        }
+        if (isset($this->pxConfig['logger']) && !($this->pxConfig['logger'] instanceof LoggerInterface)) {
+            throw new PerimeterxException(PerimeterxException::$INVALID_LOGGER);
         }
         try {
             $this->pxConfig = array_merge([

--- a/src/PerimeterxCookieValidator.php
+++ b/src/PerimeterxCookieValidator.php
@@ -121,7 +121,7 @@ class PerimeterxCookieValidator
 
             $dataTimeSec = $c_time / 1000;
             if ($dataTimeSec < time()) {
-                $this->pxConfig['logger']->warning('cookie expired');
+                $this->pxConfig['logger']->info('cookie expired');
                 $this->pxCtx->setS2SCallReason('cookie_expired');
                 return false;
             }

--- a/src/PerimeterxCookieValidator.php
+++ b/src/PerimeterxCookieValidator.php
@@ -103,7 +103,7 @@ class PerimeterxCookieValidator
             $c_hmac = $cookie->h;
 
             if (!isset($c_time, $c_score, $c_score->b, $c_uuid, $c_vid, $c_hmac)) {
-                error_log('invalid cookie');
+                $this->pxConfig['logger']->warning('invalid cookie');
                 $this->pxCtx->setS2SCallReason('cookie_decryption_failed');
                 return false;
             }
@@ -113,7 +113,7 @@ class PerimeterxCookieValidator
             $this->pxCtx->setUuid($c_uuid);
             $this->pxCtx->setVid($c_vid);
             if ($c_score->b >= $this->pxConfig['blocking_score']) {
-                error_log('cookie high score');
+                $this->pxConfig['logger']->info('cookie high score');
                 $this->pxCtx->setBlockReason('cookie_high_score');
                 $this->pxCtx->setScore($c_score->b);
                 return true;
@@ -121,7 +121,7 @@ class PerimeterxCookieValidator
 
             $dataTimeSec = $c_time / 1000;
             if ($dataTimeSec < time()) {
-                error_log('cookie expired');
+                $this->pxConfig['logger']->warning('cookie expired');
                 $this->pxCtx->setS2SCallReason('cookie_expired');
                 return false;
             }
@@ -135,16 +135,16 @@ class PerimeterxCookieValidator
             $hmac_withoutip = hash_hmac('sha256', $hmac_str_withoutip, $this->cookieSecret);
 
             if ($hmac_withip == $c_hmac or $hmac_withoutip == $c_hmac) {
-                error_log('cookie ok');
+                $this->pxConfig['logger']->info('cookie ok');
                 $this->pxCtx->setScore($c_score->b);
                 return true;
             } else {
-                error_log('cookie invalid hmac');
+                $this->pxConfig['logger']->warning('cookie invalid hmac');
                 $this->pxCtx->setS2SCallReason('cookie_validation_failed');
                 return false;
             }
         } catch (\Exception $e) {
-            error_log('exception while verifying cookie');
+            $this->pxConfig['logger']->error('exception while verifying cookie');
             $this->pxCtx->setS2SCallReason('cookie_decryption_failed');
             return false;
         }

--- a/src/PerimeterxException.php
+++ b/src/PerimeterxException.php
@@ -10,4 +10,5 @@ final class PerimeterxException extends \Exception
     public static $APP_ID_MISSING = 'perimeterx application id is required';
     public static $AUTH_TOKEN_MISSING = 'perimeterx auth token is required';
     public static $COOKIE_MISSING  = 'perimeterx cookie key is required';
+    public static $INVALID_LOGGER  = 'perimeterx logger must implement \Psr\Log\LoggerInterface';
 }

--- a/src/PerimeterxHttpClient.php
+++ b/src/PerimeterxHttpClient.php
@@ -14,11 +14,17 @@ class PerimeterxHttpClient
     protected $client;
 
     /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param \GuzzleHttp\Client|null The Guzzle client.
      */
     public function __construct($config)
     {
         $this->client = new Client(['base_uri' => $config['perimeterx_server_host']]);
+        $this->logger = $config['logger'];
     }
 
     /**
@@ -30,14 +36,14 @@ class PerimeterxHttpClient
         try {
             $rawResponse = $this->client->request($method, $url,
                 [
-                'json' => $json, 
-                'headers' => $headers, 
+                'json' => $json,
+                'headers' => $headers,
                 'timeout' => $timeout,
                 'connect_timeout' => $connect_timeout
                 ]
             );
         } catch (RequestException $e) {
-            error_log('http error ' . $e->getCode() . ' ' . $e->getMessage());
+            $this->logger->error('http error ' . $e->getCode() . ' ' . $e->getMessage());
             return json_encode(['error_msg' => $e->getMessage()]);
         }
 

--- a/src/PerimeterxLogger.php
+++ b/src/PerimeterxLogger.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Perimeterx;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LogLevel;
+
+class PerimeterxLogger extends AbstractLogger
+{
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed  $level
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $valid_log_levels = [
+            LogLevel::EMERGENCY,
+            LogLevel::ALERT,
+            LogLevel::CRITICAL,
+            LogLevel::ERROR,
+            LogLevel::WARNING,
+            LogLevel::NOTICE,
+            LogLevel::INFO,
+            LogLevel::DEBUG,
+        ];
+
+        if (!in_array($level, $valid_log_levels)) {
+            throw new InvalidArgumentException($level . ' is not a defined level in the PSR-3 specification.');
+        }
+
+        error_log($this->interpolate((string)$message, $context));
+    }
+
+    /**
+     * interpolate the message
+     *
+     * > 1.2 Message
+     * > - The message MAY contain placeholders which implementors MAY replace with values from the context array.
+     * > - Placeholder names MUST correspond to keys in the context array.
+     * > - Placeholder names MUST be delimited with a single opening brace { and a single closing brace }. There MUST NOT be any whitespace between the delimiters and the placeholder name.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return string
+     */
+    private function interpolate($message, array $context = [])
+    {
+        // build a replacement array with braces around the context keys
+        $replace = [];
+        foreach ($context as $key => $val) {
+            // check that the value can be casted to string
+            if (!is_array($val) && (!is_object($val) || method_exists($val, '__toString'))) {
+                $replace['{' . $key . '}'] = $val;
+            }
+        }
+
+        // interpolate replacement values into the message and return
+        return strtr($message, $replace);
+    }
+}


### PR DESCRIPTION
In order to abstract logging, this allows for a PSR-3 compatible logger to be sent in through the configuration array. Otherwise, the added `PerimeterxLogger` continues to rely on `error_log`. The `psr\log` library also includes the `Psr\Log\NullLogger` in the cases where logs are not desired.