### PR TITLE
Add Risk Reset

### DIFF
--- a/src/Perimeterx.php
+++ b/src/Perimeterx.php
@@ -164,4 +164,27 @@ final class Perimeterx
             return 1;
         }
     }
+
+    public function pxReset()
+    {
+        try {
+            if (!$this->pxConfig['module_enabled']) {
+                return 1;
+            }
+
+            $pxCtx = new PerimeterxContext($this->pxConfig);
+
+            $cookie = New PerimeterxCookie($pxCtx, $this->pxConfig);
+            if ($cookie->isValid()) {
+                $pxCtx->setVid($cookie->getVid());
+            }
+
+            $client = new PerimeterxResetClient($pxCtx, $this->pxConfig);
+            $client->sendResetRequest();
+        } catch (\Exception $e) {
+            $this->pxConfig['logger']->error('Uncaught exception while resetting perimeterx score' . $e->getCode() . ' ' . $e->getMessage());
+
+            return 1;
+        }
+    }
 }

--- a/src/Perimeterx.php
+++ b/src/Perimeterx.php
@@ -165,6 +165,9 @@ final class Perimeterx
         }
     }
 
+    /**
+     * Public function that contact PerimeterX servers and reset user's score from cache. can be used as part of internal flows
+     */
     public function pxReset()
     {
         try {
@@ -173,8 +176,7 @@ final class Perimeterx
             }
 
             $pxCtx = new PerimeterxContext($this->pxConfig);
-
-            $cookie = New PerimeterxCookie($pxCtx, $this->pxConfig);
+            $cookie = new PerimeterxCookie($pxCtx, $this->pxConfig);
             if ($cookie->isValid()) {
                 $pxCtx->setVid($cookie->getVid());
             }

--- a/src/PerimeterxCaptchaValidator.php
+++ b/src/PerimeterxCaptchaValidator.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Perimeterx;
 
-class PerimeterxCaptchaValidator
+class PerimeterxCaptchaValidator extends PerimeterxRiskClient
 {
     /**
      * @var string
@@ -9,37 +10,13 @@ class PerimeterxCaptchaValidator
     private $pxCaptcha;
 
     /**
-     * @var PerimeterxContext
-     */
-    private $pxCtx;
-
-    /**
-     * @var object - perimeterx configuration object
-     */
-    private $pxConfig;
-
-    /**
-     * @var string
-     */
-    private $pxAuthToken;
-
-
-    /**
-     * @var PerimeterxHttpClient
-     */
-    private $httpClient;
-
-    /**
      * @param $pxCtx PerimeterxContext - perimeterx context
      * @param $pxConfig array - perimeterx configurations
      */
     public function __construct($pxCtx, $pxConfig)
     {
+        parent::__construct($pxCtx, $pxConfig);
         $this->pxCaptcha = $pxCtx->getPxCaptcha();
-        $this->pxConfig = $pxConfig;
-        $this->pxCtx = $pxCtx;
-        $this->pxAuthToken = $pxConfig['auth_token'];
-        $this->httpClient = $pxConfig['http_client'];
     }
 
     private function sendCaptchaRequest($vid, $captcha)
@@ -84,18 +61,5 @@ class PerimeterxCaptchaValidator
         } catch (\Exception $e) {
             return false;
         }
-    }
-
-    /**
-     * @return array
-     */
-    private function formatHeaders()
-    {
-        $retval = [];
-        foreach ($this->pxCtx->getHeaders() as $key => $value) {
-            array_push($retval, ['name' => $key, 'value' => $value]);
-        }
-        return $retval;
-
     }
 }

--- a/src/PerimeterxCookie.php
+++ b/src/PerimeterxCookie.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Perimeterx;
+
+class PerimeterxCookie
+{
+
+    /**
+     * @var string
+     */
+    private $pxCookie;
+
+    /**
+     * @var object - perimeterx configuration object
+     */
+    private $pxConfig;
+
+    /**
+     * @var PerimeterxContext
+     */
+    private $pxCtx;
+
+    /**
+     * @var string
+     */
+    private $cookieSecret;
+
+    /**
+     * @param $pxCtx PerimeterxContext - perimeterx context
+     * @param $pxConfig array - perimeterx configurations
+     */
+    public function __construct($pxCtx, $pxConfig)
+    {
+        $this->pxCookie = $pxCtx->getPxCookie();
+        $this->pxConfig = $pxConfig;
+        $this->pxCtx = $pxCtx;
+        $this->cookieSecret = $pxConfig['cookie_key'];
+    }
+
+    /**
+     * @var \stdClass
+     */
+    private $decodedCookie;
+
+    public function getDecodedCookie()
+    {
+        return $this->decodedCookie;
+    }
+
+    public function getTime()
+    {
+        return $this->getDecodedCookie()->t;
+    }
+
+    public function getScore()
+    {
+        return $this->getDecodedCookie()->s->b;
+    }
+
+    public function getUuid()
+    {
+        return $this->getDecodedCookie()->u;
+    }
+
+    public function getVid()
+    {
+        return $this->getDecodedCookie()->v;
+    }
+
+    private function getHmac()
+    {
+        return $this->getDecodedCookie()->h;
+    }
+
+    /**
+     * Checks if the cookie's score is above the configured blocking score
+     *
+     * @return bool
+     */
+    public function isHighScore()
+    {
+        return ($this->getScore() >= $this->pxConfig['blocking_score']);
+    }
+
+    /**
+     * Checks if the cookie has expired
+     *
+     * @return bool
+     */
+    public function isExpired()
+    {
+        $dataTimeSec = $this->getTime() / 1000;
+
+        return ($dataTimeSec < time());
+    }
+
+    /**
+     * Checks that the cookie is secure via HMAC
+     *
+     * @return bool
+     */
+    public function isSecure()
+    {
+        $base_hmac_str = $this->getTime() . $this->decodedCookie->s->a . $this->getScore() . $this->getUuid() . $this->getVid();
+
+        /* hmac string with ip - for backward support */
+        $hmac_str_withip = $base_hmac_str . $this->pxCtx->getIp() . $this->pxCtx->getUserAgent();
+
+        /* hmac string with no ip */
+        $hmac_str_withoutip = $base_hmac_str . $this->pxCtx->getUserAgent();
+
+        if ($this->isHmacValid($hmac_str_withoutip, $this->getHmac()) or $this->isHmacValid($hmac_str_withip, $this->getHmac())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Deserializes an encrypted and/or encoded cookie string.
+     *
+     * This must be called before using an instance.
+     *
+     * @return bool
+     */
+    public function deserialize()
+    {
+        if ($this->pxConfig['encryption_enabled']) {
+            $cookie = $this->decrypt();
+        } else {
+            $cookie = $this->decode();
+        }
+        $cookie = json_decode($cookie);
+        if ($cookie == null) {
+            return false;
+        }
+
+        if (!isset($cookie->t, $cookie->s, $cookie->s->b, $cookie->u, $cookie->v, $cookie->h)) {
+            return false;
+        }
+
+        $this->decodedCookie = $cookie;
+
+        return true;
+    }
+
+    private function decrypt()
+    {
+        $ivlen = 16;
+        $keylen = 32;
+        $digest = 'sha256';
+
+        $cookie = $this->pxCookie;
+        list($salt, $iterations, $cookie) = explode(":", $cookie);
+        $iterations = intval($iterations);
+        $salt = base64_decode($salt);
+        $cookie = base64_decode($cookie);
+
+
+        $derivation = hash_pbkdf2($digest, $this->cookieSecret, $salt, $iterations, $ivlen + $keylen, true);
+        $key = substr($derivation, 0, $keylen);
+        $iv = substr($derivation, $keylen);
+        $cookie = mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $key, $cookie, MCRYPT_MODE_CBC, $iv);
+
+        return $this->unpad($cookie);
+    }
+
+    private function unpad($str)
+    {
+        $len = mb_strlen($str);
+        $pad = ord($str[$len - 1]);
+        if ($pad && $pad < 16) {
+            $pm = preg_match('/' . chr($pad) . '{' . $pad . '}$/', $str);
+            if ($pm) {
+                return mb_substr($str, 0, $len - $pad);
+            }
+        }
+        return $str;
+    }
+
+    /**
+     * @return string - decoded perimeterx cookie
+     */
+    private function decode()
+    {
+        $data_str = base64_decode($this->pxCookie);
+        return json_decode($data_str);
+    }
+
+    private function isHmacValid($hmac_str, $cookie_hmac)
+    {
+        $hmac = hash_hmac('sha256', $hmac_str, $this->cookieSecret);
+
+        if (function_exists('hash_equals')) {
+            return hash_equals($hmac, $cookie_hmac);
+        }
+
+        // @see http://php.net/manual/en/function.hash-equals.php#115635
+        if (strlen($hmac) != strlen($cookie_hmac)) {
+            return false;
+        } else {
+            $res = $hmac ^ $cookie_hmac;
+            $ret = false;
+            for ($i = strlen($res) - 1; $i >= 0; $i--) {
+                $ret |= ord($res[$i]);
+            }
+
+            return !$ret;
+        }
+    }
+}

--- a/src/PerimeterxCookie.php
+++ b/src/PerimeterxCookie.php
@@ -117,6 +117,16 @@ class PerimeterxCookie
     }
 
     /**
+     * Checks that the cookie was deserialized succcessfully, has not expired, and is secure
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        return $this->deserialize() && !$this->isExpired() && $this->isSecure();
+    }
+
+    /**
      * Deserializes an encrypted and/or encoded cookie string.
      *
      * This must be called before using an instance.
@@ -125,6 +135,11 @@ class PerimeterxCookie
      */
     public function deserialize()
     {
+        // only deserialize once
+        if ($this->decodedCookie !== null) {
+            return true;
+        }
+
         if ($this->pxConfig['encryption_enabled']) {
             $cookie = $this->decrypt();
         } else {

--- a/src/PerimeterxCookieValidator.php
+++ b/src/PerimeterxCookieValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Perimeterx;
 
 class PerimeterxCookieValidator
@@ -7,8 +8,6 @@ class PerimeterxCookieValidator
      * @var string
      */
     private $pxCookie;
-
-    private $cookieSecret;
 
     /**
      * @var PerimeterxContext
@@ -29,50 +28,6 @@ class PerimeterxCookieValidator
         $this->pxCookie = $pxCtx->getPxCookie();
         $this->pxConfig = $pxConfig;
         $this->pxCtx = $pxCtx;
-        $this->cookieSecret = $pxConfig['cookie_key'];
-    }
-
-    private function decrypt()
-    {
-        $ivlen = 16;
-        $keylen = 32;
-        $digest = 'sha256';
-
-        $cookie = $this->pxCookie;
-        list($salt, $iterations, $cookie) = explode(":", $cookie);
-        $iterations = intval($iterations);
-        $salt = base64_decode($salt);
-        $cookie = base64_decode($cookie);
-
-
-        $derivation = hash_pbkdf2($digest, $this->cookieSecret, $salt, $iterations, $ivlen + $keylen, true);
-        $key = substr($derivation, 0, $keylen);
-        $iv = substr($derivation, $keylen);
-        $cookie = mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $key, $cookie, MCRYPT_MODE_CBC, $iv);
-
-        return $this->unpad($cookie);
-    }
-
-    /**
-     * @return string - decoded perimeterx cookie
-     */
-    private function decode()
-    {
-        $data_str = base64_decode($this->pxCookie);
-        return json_decode($data_str);
-    }
-
-    private function unpad($str)
-    {
-        $len = mb_strlen($str);
-        $pad = ord($str[$len - 1]);
-        if ($pad && $pad < 16) {
-            $pm = preg_match('/' . chr($pad) . '{' . $pad . '}$/', $str);
-            if ($pm) {
-                return mb_substr($str, 0, $len - $pad);
-            }
-        }
-        return $str;
     }
 
     /**
@@ -86,88 +41,43 @@ class PerimeterxCookieValidator
                 return false;
             }
 
-            if ($this->pxConfig['encryption_enabled']) {
-                $cookie = $this->decrypt();
-            } else {
-                $cookie = $this->decode();
-            }
-            $cookie = json_decode($cookie);
-            if ($cookie == NULL) {
-                $this->pxCtx->setS2SCallReason('cookie_decryption_failed');
-                return false;
-            }
-            $c_time = $cookie->t;
-            $c_score = $cookie->s;
-            $c_uuid = $cookie->u;
-            $c_vid = $cookie->v;
-            $c_hmac = $cookie->h;
-
-            if (!isset($c_time, $c_score, $c_score->b, $c_uuid, $c_vid, $c_hmac)) {
+            $cookie = new PerimeterxCookie($this->pxCtx, $this->pxConfig);
+            if (!$cookie->deserialize()) {
                 $this->pxConfig['logger']->warning('invalid cookie');
                 $this->pxCtx->setS2SCallReason('cookie_decryption_failed');
                 return false;
             }
 
-            $this->pxCtx->setDecodedCookie($cookie);
-            $this->pxCtx->setScore($c_score->b);
-            $this->pxCtx->setUuid($c_uuid);
-            $this->pxCtx->setVid($c_vid);
-            if ($c_score->b >= $this->pxConfig['blocking_score']) {
+            $this->pxCtx->setDecodedCookie($cookie->getDecodedCookie());
+            $this->pxCtx->setScore($cookie->getScore());
+            $this->pxCtx->setUuid($cookie->getUuid());
+            $this->pxCtx->setVid($cookie->getVid());
+
+            if ($cookie->isHighScore()) {
                 $this->pxConfig['logger']->info('cookie high score');
                 $this->pxCtx->setBlockReason('cookie_high_score');
-                $this->pxCtx->setScore($c_score->b);
                 return true;
-            };
+            }
 
-            $dataTimeSec = $c_time / 1000;
-            if ($dataTimeSec < time()) {
+            if ($cookie->isExpired()) {
                 $this->pxConfig['logger']->info('cookie expired');
                 $this->pxCtx->setS2SCallReason('cookie_expired');
                 return false;
             }
 
-            /* hmac string with ip - for backward support */
-            $hmac_str_withip = $c_time . $c_score->a . $c_score->b . $c_uuid . $c_vid . $this->pxCtx->getIp() . $this->pxCtx->getUserAgent();
-
-            /* hmac string with no ip */
-            $hmac_str_withoutip = $c_time . $c_score->a . $c_score->b . $c_uuid . $c_vid . $this->pxCtx->getUserAgent();
-
-            if ($this->hmac_matches($hmac_str_withoutip, $c_hmac, $this->cookieSecret) or $this->hmac_matches($hmac_str_withip, $c_hmac, $this->cookieSecret)) {
-                $this->pxConfig['logger']->info('cookie ok');
-                $this->pxCtx->setScore($c_score->b);
-                return true;
-            } else {
+            if (!$cookie->isSecure()) {
                 $this->pxConfig['logger']->warning('cookie invalid hmac');
                 $this->pxCtx->setS2SCallReason('cookie_validation_failed');
                 return false;
             }
+
+            $this->pxConfig['logger']->info('cookie ok');
+
+            return true;
         } catch (\Exception $e) {
             $this->pxConfig['logger']->error('exception while verifying cookie');
             $this->pxCtx->setS2SCallReason('cookie_decryption_failed');
             return false;
-        }
-
-    }
-
-    private function hmac_matches($hmac_str, $cookie_hmac, $cookieSecret)
-    {
-        $hmac = hash_hmac('sha256', $hmac_str, $cookieSecret);
-
-        if (function_exists('hash_equals')) {
-            return hash_equals($hmac, $cookie_hmac);
-        }
-
-        // @see http://php.net/manual/en/function.hash-equals.php#115635
-        if (strlen($hmac) != strlen($cookie_hmac)) {
-            return false;
-        } else {
-            $res = $hmac ^ $cookie_hmac;
-            $ret = false;
-            for ($i = strlen($res) - 1; $i >= 0; $i--) {
-                $ret |= ord($res[$i]);
-            }
-
-            return !$ret;
         }
     }
 }

--- a/src/PerimeterxResetClient.php
+++ b/src/PerimeterxResetClient.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Perimeterx;
+
+class PerimeterxResetClient extends PerimeterxRiskClient
+{
+    const RESET_API_ENDPOINT = '/api/v1/risk/reset';
+
+    public function sendResetRequest()
+    {
+        $requestBody = [
+            'request' => [
+                'ip' => $this->pxCtx->getIp(),
+                'headers' => $this->formatHeaders(),
+                'uri' => $this->pxCtx->getUri(),
+                'url' => $this->pxCtx->getFullUrl()
+            ]
+        ];
+
+        $vid = $this->pxCtx->getVid();
+        if (isset($vid)) {
+            $requestBody['vid'] = $vid;
+        }
+
+        $headers = [
+            'Authorization' => 'Bearer ' . $this->pxConfig['auth_token'],
+            'Content-Type' => 'application/json'
+        ];
+
+        $response = $this->httpClient->send(self::RESET_API_ENDPOINT, 'POST', $requestBody, $headers, $this->pxConfig['api_timeout'], $this->pxConfig['api_connect_timeout']);
+
+        return $response;
+    }
+}

--- a/src/PerimeterxRiskClient.php
+++ b/src/PerimeterxRiskClient.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Perimeterx;
+
+abstract class PerimeterxRiskClient
+{
+
+    /**
+     * @var PerimeterxContext
+     */
+    protected $pxCtx;
+
+    /**
+     * @var object - perimeterx configuration object
+     */
+    protected $pxConfig;
+
+    /**
+     * @var PerimeterxHttpClient
+     */
+    protected $httpClient;
+
+    /**
+     * @param $pxCtx PerimeterxContext - perimeterx context
+     * @param $pxConfig array - perimeterx configurations
+     */
+    public function __construct($pxCtx, $pxConfig)
+    {
+        $this->pxCtx = $pxCtx;
+        $this->pxConfig = $pxConfig;
+        $this->httpClient = $pxConfig['http_client'];
+    }
+
+    /**
+     * @return array
+     */
+    protected function formatHeaders()
+    {
+        $retval = [];
+        foreach ($this->pxCtx->getHeaders() as $key => $value) {
+            if (!in_array(strtolower($key), $this->pxConfig['sensitive_headers'])) {
+                array_push($retval, ['name' => $key, 'value' => $value]);
+            }
+        }
+
+        return $retval;
+    }
+}

--- a/src/PerimeterxS2SValidator.php
+++ b/src/PerimeterxS2SValidator.php
@@ -1,40 +1,10 @@
 <?php
+
 namespace Perimeterx;
 
-class PerimeterxS2SValidator
+class PerimeterxS2SValidator extends PerimeterxRiskClient
 {
     const RISK_API_ENDPOINT = '/api/v1/risk';
-    /**
-     * @var string
-     */
-    private $pxAuthToken;
-
-    /**
-     * @var PerimeterxContext
-     */
-    private $pxCtx;
-
-    /**
-     * @var object - perimeterx configuration object
-     */
-    private $pxConfig;
-
-    /**
-     * @var PerimeterxHttpClient
-     */
-    private $httpClient;
-
-    /**
-     * @param $pxCtx PerimeterxContext - perimeterx context
-     * @param $pxConfig array - perimeterx configurations
-     */
-    public function __construct($pxCtx, $pxConfig)
-    {
-        $this->pxConfig = $pxConfig;
-        $this->pxAuthToken = $pxConfig['auth_token'];
-        $this->httpClient = $pxConfig['http_client'];
-        $this->pxCtx = $pxCtx;
-    }
 
     private function sendRiskRequest()
     {
@@ -86,21 +56,6 @@ class PerimeterxS2SValidator
             $response = $this->httpClient->send(self::RISK_API_ENDPOINT, 'POST', $requestBody, $headers, $this->pxConfig['api_timeout'], $this->pxConfig['api_connect_timeout']);
         }
         return $response;
-    }
-
-    /**
-     * @return array
-     */
-    private function formatHeaders()
-    {
-        $retval = [];
-        foreach ($this->pxCtx->getHeaders() as $key => $value) {
-            if (!in_array(strtolower($key), $this->pxConfig['sensitive_headers'])) {
-                array_push($retval, ['name' => $key, 'value' => $value]);
-            }
-        }
-        return $retval;
-
     }
 
     public function verify()

--- a/tests/PerimeterxCookieValidatorTest.php
+++ b/tests/PerimeterxCookieValidatorTest.php
@@ -46,7 +46,7 @@ class PerimeterxCookieValidatorTest extends TestCase
             'encryption_enabled' => false,
             'cookie_key' => self::COOKIE_KEY,
             'blocking_score' => 70,
-            'logger' => $this->getMockLogger(),
+            'logger' => $this->getMockLogger('warning', 'invalid cookie'),
         ];
 
         $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);

--- a/tests/PerimeterxCookieValidatorTest.php
+++ b/tests/PerimeterxCookieValidatorTest.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace Perimeterx\Tests;
+
+use Perimeterx\PerimeterxContext;
+use Perimeterx\PerimeterxCookieValidator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+
+class PerimeterxCookieValidatorTest extends TestCase
+{
+
+    // randomly generated fake values
+    const COOKIE_KEY = '549Z5UsasvfmVS6kAR3r4ydPnQdnnW4Gcwk35hj5tatZ5B2dqjrQvMMyLAJN5de3';
+    const COOKIE_UUID = '9e70ed8b-c205-4a9d-bf3a-e92a945be600';
+    const COOKIE_VID = '69521dce-ab65-11e6-80f5-76304dec7eb7';
+
+    public function testNoCookie() {
+
+        $pxCookie = null;
+        $userAgent = 'Mozilla';
+        $ip = '10.10.10.10';
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, $ip);
+
+        $pxConfig = [
+            'encryption_enabled' => false,
+            'cookie_key' => self::COOKIE_KEY,
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger(),
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertFalse($v->verify());
+        $this->assertPxContext($pxCtx, null, null, null, null, 'no_cookie', null);
+    }
+
+    public function testBadlyEncodedCookie() {
+
+        $pxCookie = 'this is not base64 encoded json';
+        $userAgent = 'Mozilla';
+        $ip = '10.10.10.10';
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, $ip);
+
+        $pxConfig = [
+            'encryption_enabled' => false,
+            'cookie_key' => self::COOKIE_KEY,
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger(),
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertFalse($v->verify());
+        $this->assertPxContext($pxCtx, null, null, null, null, 'cookie_decryption_failed', null);
+    }
+
+    public function testMissingCookieContentsThrowsException() {
+
+        $cookie_uuid = self::COOKIE_UUID;
+        $cookie_vid = self::COOKIE_VID;
+        $cookie_hmac = 'something';
+        $cookie_score_a = 0;
+        $cookie_score_b = 0;
+
+        $pxCookie = $this->encodeCookie(
+            [
+                // missing `t` value on purpose to cause an exception on cookie->t
+                'v' => $cookie_uuid,
+                'u' => $cookie_vid,
+                'h' => $cookie_hmac,
+                's' => [
+                    'a' => $cookie_score_a,
+                    'b' => $cookie_score_b,
+                ],
+            ]
+        );
+        $userAgent = 'Mozilla';
+        $ip = '10.10.10.10';
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, $ip);
+
+        $pxConfig = [
+            'encryption_enabled' => false,
+            'cookie_key' => self::COOKIE_KEY,
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger('error', 'exception while verifying cookie'),
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertFalse($v->verify());
+        $this->assertPxContext($pxCtx, null, null, null, null, 'cookie_decryption_failed', null);
+    }
+
+    public function testInvalidCookieContents() {
+
+        $cookie_time = (time() + 1000) * 1000;
+        $cookie_uuid = null;
+        $cookie_vid = self::COOKIE_VID;
+        $cookie_hmac = 'something';
+        $cookie_score_a = 0;
+        $cookie_score_b = 0;
+
+        $pxCookie = $this->encodeCookie(
+            $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b)
+        );
+        $userAgent = 'Mozilla';
+        $ip = '10.10.10.10';
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, $ip);
+
+        $pxConfig = [
+            'encryption_enabled' => false,
+            'cookie_key' => 'asdf',
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger('warning', 'invalid cookie'),
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertFalse($v->verify());
+        $this->assertPxContext($pxCtx, null, null, null, null, 'cookie_decryption_failed', null);
+    }
+
+    public function testCookieHighScore() {
+
+        $cookie_time = (time() + 1000) * 1000;
+        $cookie_uuid = self::COOKIE_UUID;
+        $cookie_vid = self::COOKIE_VID;
+        $cookie_hmac = 'something';
+        $cookie_score_a = 0;
+        $cookie_score_b = 100;
+
+        $pxCookie = $this->encodeCookie(
+            $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b)
+        );
+        $userAgent = 'Mozilla';
+        $ip = '10.10.10.10';
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, $ip);
+
+        $pxConfig = [
+            'encryption_enabled' => false,
+            'cookie_key' => self::COOKIE_KEY,
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger('info', 'cookie high score'),
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertTrue($v->verify());
+        $this->assertPxContext(
+            $pxCtx,
+            $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b),
+            $cookie_uuid,
+            $cookie_vid,
+            $cookie_score_b,
+            null,
+            'cookie_high_score'
+        );
+    }
+
+    public function testCookieExpired() {
+
+        $cookie_time = (time() - 1000) * 1000;
+        $cookie_uuid = self::COOKIE_UUID;
+        $cookie_vid = self::COOKIE_VID;
+        $cookie_hmac = 'something';
+        $cookie_score_a = 0;
+        $cookie_score_b = 0;
+
+        $pxCookie = $this->encodeCookie(
+            $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b)
+        );
+        $userAgent = 'Mozilla';
+        $ip = '10.10.10.10';
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, $ip);
+
+        $pxConfig = [
+            'encryption_enabled' => false,
+            'cookie_key' => self::COOKIE_KEY,
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger('info', 'cookie expired'),
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertFalse($v->verify());
+        $this->assertPxContext(
+            $pxCtx,
+            $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b),
+            $cookie_uuid,
+            $cookie_vid,
+            $cookie_score_b,
+            'cookie_expired',
+            null
+        );
+    }
+
+    public function testCookieHmacInvalid() {
+
+        $cookie_time = (time() + 1000) * 1000;
+        $cookie_uuid = self::COOKIE_UUID;
+        $cookie_vid = self::COOKIE_VID;
+        $cookie_hmac = 'something';
+        $cookie_score_a = 0;
+        $cookie_score_b = 0;
+
+        $pxCookie = $this->encodeCookie(
+            $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b)
+        );
+        $userAgent = 'Mozilla';
+        $ip = '10.10.10.10';
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, $ip);
+
+        $pxConfig = [
+            'encryption_enabled' => false,
+            'cookie_key' => self::COOKIE_KEY,
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger('warning', 'cookie invalid hmac'),
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertFalse($v->verify());
+        $this->assertPxContext(
+            $pxCtx,
+            $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b),
+            $cookie_uuid,
+            $cookie_vid,
+            $cookie_score_b,
+            'cookie_validation_failed',
+            null
+        );
+    }
+
+    public function testCookieHmacValid() {
+
+        // far future, consistent cookie, 2116-11-14T00:00:00Z
+        $cookie_time = '4634841600000';
+        $cookie_uuid = self::COOKIE_UUID;
+        $cookie_vid = self::COOKIE_VID;
+        // calculated at time of writing
+        $cookie_hmac = '826bb9324795dd2e621e133372a627f7b5d9523978fd1c3337389b9fa1f5cbc7';
+        $cookie_score_a = 0;
+        $cookie_score_b = 0;
+
+        $pxCookie = $this->encodeCookie(
+                $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b)
+            );
+        $userAgent = 'Mozilla';
+        $ip = '10.10.10.10';
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, $ip);
+
+        $pxConfig = [
+            'encryption_enabled' => false,
+            'cookie_key' => self::COOKIE_KEY,
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger('info', 'cookie ok'),
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertTrue($v->verify());
+        $this->assertPxContext(
+            $pxCtx,
+            $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b),
+            $cookie_uuid,
+            $cookie_vid,
+            $cookie_score_b,
+            null,
+            null
+        );
+    }
+
+    public function testCookieBackwardsCompatibleHmacValid() {
+
+        // far future, consistent cookie, 2116-11-14T00:00:00Z
+        $cookie_time = '4634841600000';
+        $cookie_uuid = self::COOKIE_UUID;
+        $cookie_vid = self::COOKIE_VID;
+        // calculated at time of writing
+        $cookie_hmac = '1eb773517a16c0e13c5ed826b34546db2bf61b249478ea9faed7d78e29ffa954';
+        $cookie_score_a = 0;
+        $cookie_score_b = 0;
+
+        $pxCookie = $this->encodeCookie(
+            $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b)
+        );
+        $userAgent = 'Mozilla';
+        $ip = '10.10.10.10';
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, $ip);
+
+        $pxConfig = [
+            'encryption_enabled' => false,
+            'cookie_key' => self::COOKIE_KEY,
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger('info', 'cookie ok'),
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertTrue($v->verify());
+        $this->assertPxContext(
+            $pxCtx,
+            $this->createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b),
+            $cookie_uuid,
+            $cookie_vid,
+            $cookie_score_b,
+            null,
+            null
+        );
+    }
+
+    /**
+     * assertPxContext
+     *
+     * @param PerimeterxContext $pxCtx
+     * @param \stdClass                     $decoded_cookie
+     * @param string                        $uuid
+     * @param string                        $vid
+     * @param int                           $score
+     * @param string                        $s2s_call_reason
+     * @param string                        $block_reason
+     *
+     * @return void
+     */
+    private function assertPxContext($pxCtx, $decoded_cookie, $uuid, $vid, $score, $s2s_call_reason, $block_reason) {
+        $this->assertEquals($decoded_cookie, $pxCtx->getDecodedCookie());
+        $this->assertEquals($uuid, $pxCtx->getUuid());
+        $this->assertEquals($vid, $pxCtx->getVid());
+        $this->assertEquals($score, $pxCtx->getScore());
+        $this->assertEquals($s2s_call_reason, $pxCtx->getS2SCallReason());
+        $this->assertEquals($block_reason, $pxCtx->getBlockReason());
+    }
+
+    private function getMockLogger($expected_level = null, $expected_message = null)
+    {
+        $levels = ['info', 'warning', 'error'];
+        $logger = $this->createMock(AbstractLogger::class);
+
+        foreach ($levels as $level) {
+            if ($expected_level === $level) {
+                $logger->expects($this->once())
+                    ->method($expected_level)
+                    ->with($expected_message);
+            } else {
+                $logger->expects($this->never())
+                    ->method($level);
+            }
+        }
+
+        return $logger;
+    }
+
+    private function createCookie($cookie_time, $cookie_vid, $cookie_uuid, $cookie_hmac, $cookie_score_a, $cookie_score_b)
+    {
+        $cookie = new \stdClass();
+        $cookie->s = new \stdClass();
+        $cookie->s->a = $cookie_score_a;
+        $cookie->s->b = $cookie_score_b;
+        $cookie->t = $cookie_time;
+        $cookie->v = $cookie_vid;
+        $cookie->u = $cookie_uuid;
+        $cookie->h = $cookie_hmac;
+
+        return $cookie;
+    }
+
+    private function encodeCookie($cookie)
+    {
+        $data_str = json_encode(json_encode($cookie));
+
+        return base64_encode($data_str);
+    }
+
+    /**
+     * getPxCtx
+     *
+     * @param $pxCookie
+     * @param $userAgent
+     * @param $ip
+     *
+     * @return \Perimeterx\PerimeterxContext
+     */
+    private function getPxContext($pxCookie, $userAgent, $ip)
+    {
+        $pxCtx = $this->getMockBuilder(PerimeterxContext::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getPxCookie', 'getUserAgent', 'getIp'])
+            ->getMock();
+        $pxCtx->expects($this->any())
+            ->method('getPxCookie')
+            ->willReturn($pxCookie);
+        $pxCtx->expects($this->any())
+            ->method('getUserAgent')
+            ->willReturn($userAgent);
+        $pxCtx->expects($this->any())
+            ->method('getIp')
+            ->willReturn($ip);
+
+        return $pxCtx;
+    }
+
+}


### PR DESCRIPTION
The Risk API supports a reset api call that is useful to call when using non-PerimeterX captchas (https://console.perimeterx.com/docs/risk_api.html#risk-reset).

In addition, this also extracts cookie decrypting/decoding logic from the `PerimeterxCookieValidator`'s s2s logic.

An abstract `PerimeterxRiskClient` has also been extracted to provide share methods between `PerimeterxResetClient`, `PerimeterxS2SValidator`, and `PerimeterxCaptchaValidator`.