### PR TITLE
UTF-8 encode all values before json encoding

### DIFF
--- a/src/Perimeterx.php
+++ b/src/Perimeterx.php
@@ -129,7 +129,7 @@ final class Perimeterx
             };
             return $this->handleVerification($pxCtx);
         } catch (\Exception $e) {
-            $this->pxConfig['logger']->error('Uncaught exception while verifying perimeterx score' . $e->getCode() . ' ' . $e->getMessage());
+            $this->pxConfig['logger']->error('Uncaught exception while verifying perimeterx score ' . $e->getCode() . ' ' . $e->getMessage());
             return 1;
         }
     }

--- a/src/PerimeterxHttpClient.php
+++ b/src/PerimeterxHttpClient.php
@@ -34,6 +34,14 @@ class PerimeterxHttpClient
     public function send($url, $method, $json, $headers, $timeout = 0, $connect_timeout = 0)
     {
         try {
+            // ensure incoming array is UTF-8 encoded to avoid JSON_ERROR_UTF8 errors
+            array_walk_recursive(
+                $json,
+                function (&$value) {
+                    $value = utf8_encode($value);
+                }
+            );
+
             $rawResponse = $this->client->request($method, $url,
                 [
                 'json' => $json,


### PR DESCRIPTION
Certain clients/bots send different encoded uri values which could cause `json_encode` to error. This ensures all data being serialized for the PerimeterX API is utf8 encoded.

We particularly saw this with Facebook's user-agent, but was able to reproduce with curl examples below.

Produces an error from Guzzle/json_encode:

```
curl -X GET -v "$(echo 'https://www.example.com/path/to/unicode-char®' | iconv -f utf-8 -t ISO-8859-1)" -sS -w "\n"
```

Does not produce an error:

```
curl -X GET -v 'https://www.example.com/path/to/unicode-char®' -sS -w "\n"
```