### PR TITLE
EN-3807 - better delimiter handling for X-PX-AUTHORIZATION

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ before_script:
   - composer install --dev
   - composer update
 
-script: phpunit tests/PerimeterxCookieValidatorTest
-script: phpunit tests/PerimeterxCookieV3ValidatorTest
-
+script:
+  - phpunit tests/PerimeterxCookieValidatorTest
+  - phpunit tests/PerimeterxCookieV3ValidatorTest
+  - phpunit tests/PerimeterxConfigurationValidatorTest
+  - phpunit tests/PerimeterxS2SValidatorTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ before_script:
   - composer update
 
 script: phpunit tests/PerimeterxCookieValidatorTest
+script: phpunit tests/PerimeterxCookieV3ValidatorTest
+

--- a/src/Perimeterx.php
+++ b/src/Perimeterx.php
@@ -223,7 +223,7 @@ final class Perimeterx
             $html = $mustache->render('block', $templateInputs);
         }
 
-        header("Status: 403");
+        header("HTTP/1.1 403 Forbidden");
         if ($pxCtx->getCookieOrigin() == 'cookie') {
             header("Content-Type: text/html");
             echo $html;

--- a/src/PerimeterxContext.php
+++ b/src/PerimeterxContext.php
@@ -452,7 +452,7 @@ class PerimeterxContext
     }
 
     private function explodeCookieToVersion($delimiter, $cookie) {
-        if (strpos($delimiter, $cookie) !== false) {
+        if (strpos($cookie, $delimiter)) {
             list($k, $v) = explode($delimiter, $cookie, 2);
             if ($k == '3' || $k == '_px3') {
                 $this->px_cookies['v3'] = $v;

--- a/src/PerimeterxContext.php
+++ b/src/PerimeterxContext.php
@@ -452,15 +452,17 @@ class PerimeterxContext
     }
 
     private function explodeCookieToVersion($delimiter, $cookie) {
-        list($k, $v) = explode($delimiter, $cookie, 2);
-        if ($k == '3' || $k == '_px3') {
-            $this->px_cookies['v3'] = $v;
-        }
-        if ($k == '1' || $k == '_px') {
-            $this->px_cookies['v1'] = $v;
-        }
-        if ($k == '_pxCaptcha') {
-            $this->px_captcha = $v;
+        if (strpos($delimiter, $cookie) !== false) {
+            list($k, $v) = explode($delimiter, $cookie, 2);
+            if ($k == '3' || $k == '_px3') {
+                $this->px_cookies['v3'] = $v;
+            }
+            if ($k == '1' || $k == '_px') {
+                $this->px_cookies['v1'] = $v;
+            }
+            if ($k == '_pxCaptcha') {
+                $this->px_captcha = $v;
+            }
         }
     }
 

--- a/src/PerimeterxCookieValidator.php
+++ b/src/PerimeterxCookieValidator.php
@@ -37,6 +37,7 @@ class PerimeterxCookieValidator
     {
         try {
             if (!isset($this->pxCookie) || (isset($this->pxCookie) && $this->pxCookie == 1)) {
+                $this->pxConfig['logger']->info('no cookie');
                 $this->pxCtx->setS2SCallReason('no_cookie');
                 return false;
             }

--- a/src/PerimeterxCookieValidator.php
+++ b/src/PerimeterxCookieValidator.php
@@ -36,12 +36,11 @@ class PerimeterxCookieValidator
     public function verify()
     {
         try {
-            if (!isset($this->pxCookie) || (isset($this->pxCookie) && $this->pxCookie == 1)) {
+            if (!isset($this->pxCookie) || (isset($this->pxCookie) && $this->pxCtx->getCookieOrigin() == "header" && $this->pxCookie == 1)) {
                 $this->pxConfig['logger']->info('no cookie');
                 $this->pxCtx->setS2SCallReason('no_cookie');
                 return false;
             }
-
             $cookie = PerimeterxPayload::pxPayloadFactory($this->pxCtx, $this->pxConfig);
             if (!$cookie->deserialize()) {
                 $this->pxConfig['logger']->warning('invalid cookie');

--- a/tests/Fixtures/PerimeterxContextGoodCookie.php
+++ b/tests/Fixtures/PerimeterxContextGoodCookie.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 
 class PerimeterxContextGoodCookie extends PerimeterxContext
 {
+
     /**
      * PerimeterxContextGoodCookie constructor.
      */
@@ -33,9 +34,38 @@ class PerimeterxContextGoodCookie extends PerimeterxContext
             'User-Agent' => $ua,
             'Content-type' => 'application/x-www-form-urlencoded'
         ];
-        
+
         $rawResponse = $httpclient->request('POST', '/api/v1/collector', ['body' => PX_ACTIVITY_PAYLOAD, 'headers' => $headers]);
         $response = json_decode($rawResponse->getBody());
-        return explode("|", $response->do[1])[3];
+        $px_cookie = explode("|", $response->do[1])[3];
+        return $px_cookie;
     }
+
+    public function getPxCookie(){
+        return $this->px_cookie;
+    }
+
+    public function getPxCookies(){
+        return ["V1" => $this->getPxCookie() ];
+    }
+
+    public function getUserAgent(){
+        return $this->userAgent;
+    }
+
+    public function isSensitiveRoute(){
+        return false;
+    }
+
+    public function getCookieOrigin(){
+        return "cookie";
+    }
+
+    public function setDecodedCookie($val){}
+    public function setScore($val){}
+    public function setUuid($val){}
+    public function setVid($val){}
+    public function setBlockAction($val){}
+    public function setCookieHmac($val){}
+    public function setPassReason($val){}
 }

--- a/tests/PerimeterxCookieTest.php
+++ b/tests/PerimeterxCookieTest.php
@@ -1,25 +1,42 @@
 <?php
 
-namespace Perimeterx\Tests;
 
+use Psr\Log\AbstractLogger;
 use Perimeterx\PerimeterxCookieValidator;
 use Perimeterx\Tests\Fixtures\PerimeterxContextGoodCookie;
 
-class PerimeterxCookieTest extends TestCase
+class PerimeterxCookieTest extends PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
     }
-    
+
     public function testGoodCookie() {
         $ctx = new PerimeterxContextGoodCookie();
         $pxCookieValidator = new PerimeterxCookieValidator($ctx, [
             'cookie_key' => PX_COOKIE_KEY,
             'encryption_enabled' => true,
-            'blocking_score' => 60
+            'blocking_score' => 60,
+            'logger' => $this->getMockLogger('info', 'cookie ok')
         ]);
 
         $verify = $pxCookieValidator->verify();
         $this->assertTrue($verify);
+    }
+
+    private function getMockLogger($expected_level = null, $expected_message = null)
+    {
+        $levels = ['', 'warning', 'error'];
+        $logger = $this->createMock(AbstractLogger::class);
+
+        foreach ($levels as $level) {
+            if ($expected_level === $level) {
+                $logger->expects($this->once())
+                    ->method($expected_level)
+                    ->with($expected_message);
+            }
+        }
+
+        return $logger;
     }
 }

--- a/tests/PerimeterxCookieV3ValidatorTest.php
+++ b/tests/PerimeterxCookieV3ValidatorTest.php
@@ -26,7 +26,7 @@ class PerimeterxCookieValidatorTest extends PHPUnit_Framework_TestCase
             'encryption_enabled' => false,
             'cookie_key' => self::COOKIE_KEY,
             'blocking_score' => 70,
-            'logger' => $this->getMockLogger(),
+            'logger' => $this->getMockLogger('info', 'no cookie')
         ];
 
         $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
@@ -262,7 +262,7 @@ class PerimeterxCookieValidatorTest extends PHPUnit_Framework_TestCase
             'encryption_enabled' => false,
             'cookie_key' => self::COOKIE_KEY,
             'blocking_score' => 70,
-            'logger' => $this->getMockLogger(),
+            'logger' => $this->getMockLogger('info', 'no cookie')
         ];
 
         $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);

--- a/tests/PerimeterxCookieV3ValidatorTest.php
+++ b/tests/PerimeterxCookieV3ValidatorTest.php
@@ -6,7 +6,7 @@ use Perimeterx\PerimeterxCookieValidator;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
 
-class PerimeterxCookieValidatorTest extends PHPUnit_Framework_TestCase
+class PerimeterxCookieV3ValidatorTest extends PHPUnit_Framework_TestCase
 {
 
     // randomly generated fake values

--- a/tests/PerimeterxCookieValidatorTest.php
+++ b/tests/PerimeterxCookieValidatorTest.php
@@ -28,7 +28,7 @@ class PerimeterxCookieValidatorTest extends PHPUnit_Framework_TestCase
             'encryption_enabled' => false,
             'cookie_key' => self::COOKIE_KEY,
             'blocking_score' => 70,
-            'logger' => $this->getMockLogger(),
+            'logger' => $this->getMockLogger('info', 'no cookie')
         ];
 
         $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
@@ -359,7 +359,7 @@ class PerimeterxCookieValidatorTest extends PHPUnit_Framework_TestCase
             'encryption_enabled' => false,
             'cookie_key' => self::COOKIE_KEY,
             'blocking_score' => 70,
-            'logger' => $this->getMockLogger(),
+            'logger' => $this->getMockLogger('info', 'no cookie')
         ];
 
         $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);


### PR DESCRIPTION
1) added a check for delimiter present in the cookie
2) added log output for no cookie
3) fixed http status to 403 (instead of 200) on block