### PR TITLE
EN-3807 Security Fixes

### DIFF
--- a/src/CookieV3.php
+++ b/src/CookieV3.php
@@ -11,8 +11,14 @@ class CookieV3 extends PerimeterxCookie
      */
     public function __construct($pxCtx, $pxConfig)
     {
+        if ($pxConfig['encryption_enabled']) {
+            $cookieValidPartsNumber = 4;
+        } else {
+            $cookieValidPartsNumber = 2;
+        }
+
         $payloadParts = explode(":", $pxCtx->getPxCookie());
-        if (count($payloadParts) < 4) {
+        if (count($payloadParts) < $cookieValidPartsNumber) {
             return null;
         }
         list($hash, $cookie) = explode(":", $pxCtx->getPxCookie(), 2);

--- a/src/CookieV3.php
+++ b/src/CookieV3.php
@@ -11,6 +11,10 @@ class CookieV3 extends PerimeterxCookie
      */
     public function __construct($pxCtx, $pxConfig)
     {
+        $payloadParts = explode(":", $pxCtx->getPxCookie());
+        if (count($payloadParts) < 4) {
+            return null;
+        }
         list($hash, $cookie) = explode(":", $pxCtx->getPxCookie(), 2);
         $this->pxPayload = $cookie;
         $this->cookieHash = $hash;
@@ -46,9 +50,6 @@ class CookieV3 extends PerimeterxCookie
     {
         $hmac_string = $this->pxPayload.$this->pxCtx->getUserAgent();
 
-        if ($this->isHmacValid($hmac_string, $this->getHmac())) {
-            return true;
-        }
-        return false;
+        return $this->isHmacValid($hmac_string, $this->getHmac());
     }
 }

--- a/src/PerimeterxContext.php
+++ b/src/PerimeterxContext.php
@@ -13,14 +13,6 @@ class PerimeterxContext
 
         $this->cookie_origin = "cookie";
 
-        if (isset($_SERVER['HTTP_COOKIE'])) {
-            foreach (explode('; ', $_SERVER['HTTP_COOKIE']) as $rawcookie) {
-                if (!empty($rawcookie) && strpos($rawcookie, '=') !== false) {
-                    $this->explodeCookieToVersion('=', $rawcookie);
-                }
-            }
-        }
-
         $this->start_time = microtime(true);
         if (function_exists('getallheaders')) {
             $this->headers = getallheaders();
@@ -37,6 +29,12 @@ class PerimeterxContext
             $this->cookie_origin = "header";
             if ($this->headers[PerimeterxContext::$MOBILE_SDK_HEADER] != "1") {
                 $this->explodeCookieToVersion(':', $this->headers[PerimeterxContext::$MOBILE_SDK_HEADER]);
+            }
+        } else if (isset($_SERVER['HTTP_COOKIE'])) {
+            foreach (explode('; ', $_SERVER['HTTP_COOKIE']) as $rawcookie) {
+                if (!empty($rawcookie) && strpos($rawcookie, '=') !== false) {
+                    $this->explodeCookieToVersion('=', $rawcookie);
+                }
             }
         }
 
@@ -463,6 +461,8 @@ class PerimeterxContext
             if ($k == '_pxCaptcha') {
                 $this->px_captcha = $v;
             }
+        } else {
+            $this->px_cookies['v3'] = $cookie;
         }
     }
 

--- a/src/PerimeterxCookieValidator.php
+++ b/src/PerimeterxCookieValidator.php
@@ -41,12 +41,14 @@ class PerimeterxCookieValidator
                 $this->pxCtx->setS2SCallReason('no_cookie');
                 return false;
             }
+
             $cookie = PerimeterxPayload::pxPayloadFactory($this->pxCtx, $this->pxConfig);
             if (!$cookie->deserialize()) {
                 $this->pxConfig['logger']->warning('invalid cookie');
                 $this->pxCtx->setS2SCallReason('cookie_decryption_failed');
                 return false;
             }
+
 
             $this->pxCtx->setDecodedCookie($cookie->getDecodedPayload());
             $this->pxCtx->setScore($cookie->getScore());

--- a/src/PerimeterxCookieValidator.php
+++ b/src/PerimeterxCookieValidator.php
@@ -49,7 +49,6 @@ class PerimeterxCookieValidator
                 return false;
             }
 
-
             $this->pxCtx->setDecodedCookie($cookie->getDecodedPayload());
             $this->pxCtx->setScore($cookie->getScore());
             $this->pxCtx->setUuid($cookie->getUuid());

--- a/src/PerimeterxPayload.php
+++ b/src/PerimeterxPayload.php
@@ -128,7 +128,13 @@ abstract class PerimeterxPayload {
         $digest = 'sha256';
 
         $payload = $this->getPayload();
-        list($salt, $iterations, $payload) = explode(":", $payload);
+
+        $payloadParts = explode(":", $payload);
+        if (count($payloadParts) < 3) {
+            return null;
+        }
+
+        list($salt, $iterations, $payload) = $payloadParts;
         $iterations = intval($iterations);
         $salt = base64_decode($salt);
         $payload = base64_decode($payload);

--- a/src/PerimeterxPayload.php
+++ b/src/PerimeterxPayload.php
@@ -165,7 +165,7 @@ abstract class PerimeterxPayload {
      */
     private function decode()
     {
-        $data_str = base64_decode($this->pxPayload);
+        $data_str = base64_decode($this->getPayload());
         return json_decode($data_str);
     }
 

--- a/src/TokenV1.php
+++ b/src/TokenV1.php
@@ -43,16 +43,6 @@ class TokenV1 extends PerimeterxToken
     public function isSecure()
     {
         $base_hmac_str = $this->getTime() . $this->decodedPayload->s->a . $this->getScore() . $this->getUuid() . $this->getVid();
-
-        /* hmac string with ip - for backward support */
-        $hmac_str_withip = $base_hmac_str . $this->pxCtx->getIp();
-
-        /* hmac string with no ip */
-        $hmac_str_withoutip = $base_hmac_str;
-        if ($this->isHmacValid($hmac_str_withoutip, $this->getHmac()) or $this->isHmacValid($hmac_str_withip, $this->getHmac())) {
-            return true;
-        }
-
-        return false;
+        return $this->isHmacValid($base_hmac_str, $this->getHmac());
     }
 }

--- a/src/TokenV3.php
+++ b/src/TokenV3.php
@@ -10,6 +10,10 @@ class TokenV3 extends PerimeterxToken
      */
     public function __construct($pxCtx, $pxConfig)
     {
+        $payloadParts = explode(":", $pxCtx->getPxCookie());
+        if (count($payloadParts) < 4) {
+            return null;
+        }
         list($hash, $token) = explode(":", $pxCtx->getPxCookie(), 2);
         $this->pxPayload = $token;
         $this->tokenHash = $hash;

--- a/src/TokenV3.php
+++ b/src/TokenV3.php
@@ -10,8 +10,14 @@ class TokenV3 extends PerimeterxToken
      */
     public function __construct($pxCtx, $pxConfig)
     {
+        if ($pxConfig['encryption_enabled']) {
+            $cookieValidPartsNumber = 4;
+        } else {
+            $cookieValidPartsNumber = 2;
+        }
+
         $payloadParts = explode(":", $pxCtx->getPxCookie());
-        if (count($payloadParts) < 4) {
+        if (count($payloadParts) < $cookieValidPartsNumber) {
             return null;
         }
         list($hash, $token) = explode(":", $pxCtx->getPxCookie(), 2);

--- a/tests/PerimeterxCookieV3ValidatorTest.php
+++ b/tests/PerimeterxCookieV3ValidatorTest.php
@@ -252,6 +252,23 @@ class PerimeterxCookieV3ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("sensitive_route", $pxCtx->getS2SCallReason());
     }
 
+    public function testEncryptedCookieDecryption() {
+        // far future encrypted cookie
+        $pxCookie = "eb34be587303f1ac7b04bed5fd5388bc3d2a0ad29a014ae6823ebfe27ba59ed4:2EK7x6pHyMwy6pB9PmYKhX7YaiAf3aay2MwzZhS+x8G/htGX6xfjbLt8Gkn3cgggpD/6ykXk5XjZ7UG9TePOiQ==:1000:8HgbjMrrYXbYhVwh8e0+Vnsg051OvqpKfYkZjzPZLIKyVCjwL5ufPj8s3BXl1bBTdhwqRXUZnq1vJuBpOoTBdrC+AUL/kYqLmW6JyF+MpjfIdKaSqGZag2qZRFGMJSSf3EBVZevInEbZMoNBjLAsHnbJAToZ2+ejIIIM6XmBGqo=";
+        $userAgent = self::USER_AGENT;
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, false);
+        $pxConfig = [
+            'encryption_enabled' => true,
+            'cookie_key' => self::COOKIE_KEY,
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger('info', 'cookie ok')
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertTrue($v->verify());
+    }
+
     // mobile sdk token testings
     public function testNoMobileHeaderCookie() {
         $pxCookie = 1;
@@ -491,6 +508,24 @@ class PerimeterxCookieV3ValidatorTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($v->verify());
         $this->assertEquals("sensitive_route", $pxCtx->getS2SCallReason());
+    }
+
+    public function testEncryptedTokenDecryption() {
+        // far future encrypted cookie
+        $cookie_origin="header";
+        $pxCookie = "8d4a0f41e65af5088266f1eb0db7bd4266309d3c471c097aea538e17c1ebe82d:mmjSIpdOpbZYsDjXe0vAieBbrG7k8JVJO2+9itMXUoZfugSlvRIqK4BUKPDAd2gftZtbwU0eA5LZXHf8VURI/w==:1000:KFCP3EU4qtGhRab+OgIYeg0SXhXWWfmSvmTK6+4J5vwN73/IVx/BkcRzC1inFxJ2jCHr+KqcQxEpcqyO1E91l2Wk38ddADYzuog3KhbsV9j2wXldnX0zWkc7dgnRHc8xJuck4NfrZivdfQNA0AC4k+z0sasqwRWQ5Eq1mjnIwf8=";
+        $userAgent = self::USER_AGENT;
+        $pxCtx = $this->getPxContext($pxCookie, $userAgent, false, $cookie_origin);
+        $pxConfig = [
+            'encryption_enabled' => true,
+            'cookie_key' => self::COOKIE_KEY,
+            'blocking_score' => 70,
+            'logger' => $this->getMockLogger('info', 'cookie ok')
+        ];
+
+        $v = new PerimeterxCookieValidator($pxCtx, $pxConfig);
+
+        $this->assertTrue($v->verify());
     }
 
     // private functions


### PR DESCRIPTION
1. fixed bug with X-PX-AUTHORIZATION getting a bad header (i.e 1:asdasdsadas or just asdsadas) 
2. fixed crashing in case of cookie without delimiter (i.e. _px3=kjsdfhgkjdfg )
3. fixed cookies getting checked if no header is presented.
4. fixed tests
5. added 2 tests for V3 encrypted token/cookie