### PR TITLE
Everything should be lower case

### DIFF
--- a/src/Perimeterx.php
+++ b/src/Perimeterx.php
@@ -25,6 +25,7 @@
 
 namespace Perimeterx;
 
+
 use Psr\Log\LoggerInterface;
 
 final class Perimeterx
@@ -216,7 +217,8 @@ final class Perimeterx
             return 1;
         }
 
-        $should_bypass_monitor = isset($this->pxConfig['bypass_monitor_header']) && isset($pxCtx->getHeaders()[$this->pxConfig['bypass_monitor_header']]) && $pxCtx->getHeaders()[$this->pxConfig['bypass_monitor_header']] == "1";
+        $headers = array_change_key_case($pxCtx->getHeaders(), CASE_LOWER);
+        $should_bypass_monitor = isset($this->pxConfig['bypass_monitor_header']) && isset($headers[strtolower($this->pxConfig['bypass_monitor_header'])]) && $headers[strtolower($this->pxConfig['bypass_monitor_header'])] == "1";
         if ($this->pxConfig['module_mode'] != Perimeterx::$ACTIVE_MODE && !$should_bypass_monitor ) {
             return 1;
         }


### PR DESCRIPTION
The customer tried to compare the config with the header with no success

According to the RFC, headers should be case insensitive, therefore everything will be compared lowercase