### PR TITLE
Fix hostURL typo in return array for web

### DIFF
--- a/src/Perimeterx.php
+++ b/src/Perimeterx.php
@@ -286,7 +286,7 @@ final class Perimeterx
                     'firstPartyEnabled' => false,
                     'vid' => $templateInputs['vid'],
                     'uuid' => $templateInputs['uuid'],
-                    'hostUr' => $templateInputs['hostUrl'],
+                    'hostUrl' => $templateInputs['hostUrl'],
                     'blockScript' => $templateInputs['blockScript']
                 );
                 if ($this->pxConfig['return_response']) {


### PR DESCRIPTION
The "hostURL" key has a slight typo in the return array for web, when the response is JSON instead of HTML.

The "hostURL" key should match what's in the template setup:
https://github.com/PerimeterX/perimeterx-php-sdk/blob/master/src/Perimeterx.php#L249
