### PR TITLE
pxhd illegal characters: sanitizing cookie before setting it

### DIFF
--- a/src/PerimeterxS2SValidator.php
+++ b/src/PerimeterxS2SValidator.php
@@ -148,7 +148,7 @@ class PerimeterxS2SValidator extends PerimeterxRiskClient
         $this->pxCtx->setBlockAction($response->action);
         $this->pxCtx->setResponseBlockAction($response->action);
         if (isset($response->pxhd)) {
-            setrawcookie("_pxhd", $response->pxhd, time() + 31557600, "/"); // expires in 1 year
+            setrawcookie("_pxhd", PerimeterxUtils::sanitizeCookie($response->pxhd), time() + PerimeterxUtils::SECONDS_IN_YEAR, "/");
         }
         if(isset($response->data_enrichment)) {
             $this->pxCtx->setDataEnrichmentVerified(true);

--- a/src/PerimeterxUtils.php
+++ b/src/PerimeterxUtils.php
@@ -4,6 +4,8 @@ namespace Perimeterx;
 
 class PerimeterxUtils
 {
+	const SECONDS_IN_YEAR = 31557600;
+	const ILLEGAL_COOKIE_CHARS = [",", ";", " ", "\t", "\r", "\n", "\013", "\014"];
 	protected static $inputStreamName = "php://input";
 
 	private $customParamsArray = [
@@ -28,6 +30,10 @@ class PerimeterxUtils
 				}
 			}
 		}
+	}
+
+	public static function sanitizeCookie($cookieValue) {
+		return str_replace(self::ILLEGAL_COOKIE_CHARS, array_map("rawurlencode", self::ILLEGAL_COOKIE_CHARS), $cookieValue);
 	}
 
 	public static function getPostRequestBody() {

--- a/tests/PerimeterxS2SValidatorTest.php
+++ b/tests/PerimeterxS2SValidatorTest.php
@@ -46,6 +46,9 @@ class PerimeterxS2SValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($pxCookie, $last->parameters[2]["additional"]["px_cookie_orig"]);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testRiskResponseUnencodedPxhdCookie() {
         $pxhdCookie = "\this cookie has bad \values like \013 and \014 that p\roper cookies should\n't have";
 

--- a/tests/PerimeterxS2SValidatorTest.php
+++ b/tests/PerimeterxS2SValidatorTest.php
@@ -46,6 +46,27 @@ class PerimeterxS2SValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($pxCookie, $last->parameters[2]["additional"]["px_cookie_orig"]);
     }
 
+    public function testRiskResponseUnencodedPxhdCookie() {
+        $pxhdCookie = "\this cookie has bad \values like \013 and \014 that p\roper cookies should\n't have";
+
+        $http_client = $this->createMock(PerimeterxHttpClient::class);
+        $http_client->method('send')
+            ->willReturn(json_encode([
+                "status" => 0,
+                "score" => 0,
+                "action" => 'c',
+                "uuid" => "uuid",
+                "pxhd" => $pxhdCookie
+            ]));
+
+        $pxCtx = $this->getPxContext();
+        $pxConfig = $this->getPxConfig($this->getMockLogger(), $http_client);
+
+        $validator = new PerimeterxS2SValidator($pxCtx, $pxConfig);
+        // asserts that it does not throw an exception/warning
+        $this->assertNull($validator->verify());
+    }
+
     public function testS2SErrorHttpClientThrowsException() {
         $exception_message = "Exception message!";
         $http_client = $this->createMock(PerimeterxHttpClient::class);


### PR DESCRIPTION
https://perimeterx.atlassian.net/browse/SDKNEW-953

The reason I opted not to use `setcookie()` or to `rawurlencode()` the entire cookie is because we have many symbols (colon, equal sign) that are valid and required in the cookie. 